### PR TITLE
`com.uber.jaeger` is deprecated for `io.jaegertracing`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 scalaVersion := "2.12.2"
 resolvers += Resolver.mavenLocal
 resolvers += Resolver.bintrayRepo("kamon-io", "snapshots")
-libraryDependencies += "com.uber.jaeger" % "jaeger-core" % "0.21.0"
+libraryDependencies += "io.jaegertracing" % "jaeger-core" % "0.27.0"
 libraryDependencies += "io.kamon" %% "kamon-core" % "1.0.0"

--- a/src/main/scala/kamon/jaeger/JaegerReporter.scala
+++ b/src/main/scala/kamon/jaeger/JaegerReporter.scala
@@ -20,8 +20,8 @@ import java.nio.ByteBuffer
 import java.util
 
 import com.typesafe.config.Config
-import com.uber.jaeger.thriftjava.{Log, Process, Tag, TagType, Span => JaegerSpan}
-import com.uber.jaeger.senders.HttpSender
+import io.jaegertracing.thriftjava.{Log, Process, Tag, TagType, Span => JaegerSpan}
+import io.jaegertracing.senders.HttpSender
 import kamon.trace.IdentityProvider.Identifier
 import kamon.trace.Span
 import kamon.util.Clock


### PR DESCRIPTION
see https://github.com/jaegertracing/legacy-client-java/issues/13