### PR TITLE
Update to kamon 2.0.0-M4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,10 @@
 scalaVersion := "2.12.6"
 resolvers += Resolver.mavenLocal
 resolvers += Resolver.bintrayRepo("kamon-io", "snapshots")
-libraryDependencies += "io.jaegertracing" % "jaeger-thrift" % "0.30.0"
-libraryDependencies += "io.kamon" %% "kamon-core" % "1.1.3"
+libraryDependencies += ("io.jaegertracing" % "jaeger-thrift" % "0.34.0" classifier "shadow")
+  .exclude("io.jaegertracing", "jaeger-core")
+  .exclude("com.google.code.gson", "gson")
+    .exclude("io.opentracing", "opentracing-api")
+    .exclude("com.squareup.okhttp3", "okhttp")
+    .exclude("org.apache.thrift", "libthrift")
+libraryDependencies += "io.kamon" %% "kamon-core" % "2.0.0-M4"

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,6 @@
-scalaVersion := "2.12.6"
+scalaVersion := "2.13.0"
 resolvers += Resolver.mavenLocal
-resolvers += Resolver.bintrayRepo("kamon-io", "snapshots")
-libraryDependencies += ("io.jaegertracing" % "jaeger-thrift" % "0.34.0" classifier "shadow")
-  .exclude("io.jaegertracing", "jaeger-core")
-  .exclude("com.google.code.gson", "gson")
-    .exclude("io.opentracing", "opentracing-api")
-    .exclude("com.squareup.okhttp3", "okhttp")
-    .exclude("org.apache.thrift", "libthrift")
-libraryDependencies += "io.kamon" %% "kamon-core" % "2.0.0-M4"
+libraryDependencies += "io.jaegertracing" % "jaeger-thrift" % "0.35.5"
+libraryDependencies += "io.kamon" %% "kamon-core" % "2.0.0-RC1"
+
+crossScalaVersions := Seq("2.11.12", "2.12.7", "2.13.0")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-lazy val root = project in file(".") dependsOn(RootProject(uri("git://github.com/kamon-io/kamon-sbt-umbrella.git#kamon-1.x")))
+lazy val root = project in file(".") dependsOn(RootProject(uri("git://github.com/kamon-io/kamon-sbt-umbrella.git#kamon-2.x")))
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-lazy val root: Project = project.in(file(".")).dependsOn(latestSbtUmbrella)
-lazy val latestSbtUmbrella = uri("git://github.com/kamon-io/kamon-sbt-umbrella.git")
+lazy val root = project in file(".") dependsOn(RootProject(uri("git://github.com/kamon-io/kamon-sbt-umbrella.git#kamon-1.x")))
+

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -4,17 +4,16 @@ kamon {
     port = 14268
     tls = false
 
-    # Enable of disable including tags from kamon.jaeger.environment as labels
+    # Enable or disable including tags from kamon.jaeger.environment as labels
     include-environment-tags = no
   }
 
   modules {
-     jaeger {
-       enabled = true
-       name = "Kamon jaeger integration"
-       description = "A module description"
-       class = "kamon.jaeger.JaegerReporter"
-       factory = "kamon.jaeger.JaegerReporterFactory"
-     }
-   }
+    jaeger {
+      enabled = true
+      name = "Jaeger Reporter"
+      description = "Sends Spans to Jaeger over HTTP"
+      factory = "kamon.jaeger.JaegerReporterFactory"
+    }
+  }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -14,6 +14,7 @@ kamon {
        name = "Kamon jaeger integration"
        description = "A module description"
        class = "kamon.jaeger.JaegerReporter"
+       factory = "kamon.jaeger.JaegerReporterFactory"
      }
    }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -7,4 +7,13 @@ kamon {
     # Enable of disable including tags from kamon.jaeger.environment as labels
     include-environment-tags = no
   }
+
+  modules {
+     jaeger {
+       enabled = true
+       name = "Kamon jaeger integration"
+       description = "A module description"
+       class = "kamon.jaeger.JaegerReporter"
+     }
+   }
 }

--- a/src/main/scala/kamon/jaeger/JaegerReporter.scala
+++ b/src/main/scala/kamon/jaeger/JaegerReporter.scala
@@ -17,21 +17,14 @@
 package kamon.jaeger
 
 import java.nio.ByteBuffer
-import java.util
 
 import com.typesafe.config.Config
 import io.jaegertracing.thrift.internal.senders.HttpSender
-import io.jaegertracing.thriftjava.{
-  Log,
-  Process,
-  Tag,
-  TagType,
-  Span => JaegerSpan
-}
-import kamon.trace.IdentityProvider.Identifier
-import kamon.trace.Span.{Mark, TagValue, FinishedSpan => KamonSpan}
+import io.jaegertracing.thriftjava.{Log, Process, Tag, TagType, Span => JaegerSpan}
 import kamon.util.Clock
-import kamon.{Kamon, SpanReporter}
+import kamon.Kamon
+import kamon.module.SpanReporter
+import kamon.trace.{Identifier, Span}
 
 import scala.util.Try
 
@@ -45,8 +38,7 @@ class JaegerReporter extends SpanReporter {
     val host = jaegerConfig.getString("host")
     val port = jaegerConfig.getInt("port")
     val scheme = if (jaegerConfig.getBoolean("tls")) "https" else "http"
-    val includeEnvironmentTags =
-      jaegerConfig.getBoolean("include-environment-tags")
+    val includeEnvironmentTags = jaegerConfig.getBoolean("include-environment-tags")
 
     jaegerClient = new JaegerClient(host, port, scheme, includeEnvironmentTags)
   }
@@ -54,7 +46,7 @@ class JaegerReporter extends SpanReporter {
   override def start(): Unit = {}
   override def stop(): Unit = {}
 
-  override def reportSpans(spans: Seq[KamonSpan]): Unit = {
+  override def reportSpans(spans: Seq[Span.Finished]): Unit = {
     jaegerClient.sendSpans(spans)
   }
 }
@@ -70,62 +62,55 @@ class JaegerClient(host: String,
 
   if (includeEnvironmentTags)
     process.setTags(
-      Kamon.environment.tags
-        .map { case (k, v) => new Tag(k, TagType.STRING).setVStr(v) }
+      Kamon.environment.tags.iterator(_.toString)
+        .map { p => new Tag(p.key, TagType.STRING).setVStr(p.value) }
         .toList
         .asJava)
 
   val sender = new HttpSender.Builder(endpoint).build()
 
-  def sendSpans(spans: Seq[KamonSpan]): Unit = {
+  def sendSpans(spans: Seq[Span.Finished]): Unit = {
     val convertedSpans = spans.map(convertSpan).asJava
     sender.send(process, convertedSpans)
   }
 
-  private def convertSpan(kamonSpan: KamonSpan): JaegerSpan = {
-    val context = kamonSpan.context
+  private def convertSpan(kamonSpan: Span.Finished): JaegerSpan = {
     val from = Clock.toEpochMicros(kamonSpan.from)
     val duration =
       Math.floorDiv(Clock.nanosBetween(kamonSpan.from, kamonSpan.to), 1000)
 
     val convertedSpan = new JaegerSpan(
-      convertIdentifier(context.traceID),
+      convertIdentifier(kamonSpan.trace.id),
       0L,
-      convertIdentifier(context.spanID),
-      convertIdentifier(context.parentID),
+      convertIdentifier(kamonSpan.id),
+      convertIdentifier(kamonSpan.parentId),
       kamonSpan.operationName,
       0,
       from,
       duration
     )
 
-    convertedSpan.setTags(new util.ArrayList[Tag](kamonSpan.tags.size))
+    import scala.collection.JavaConverters._
+    convertedSpan.setTags(
+      kamonSpan.tags.iterator().map {
+        case t: kamon.tag.Tag.String =>
+          new Tag(t.key, TagType.STRING).setVStr(t.value)
+        case t: kamon.tag.Tag.Boolean =>
+          new Tag(t.key, TagType.BOOL).setVBool(t.value)
+        case t: kamon.tag.Tag.Long =>
+          new Tag(t.key, TagType.LONG).setVLong(t.value)
+      }.toList.asJava
+    )
 
-    kamonSpan.tags.foreach {
-      case (key, TagValue.True) =>
-        val tag = new Tag(key, TagType.BOOL).setVBool(true)
-        convertedSpan.tags.add(tag)
-
-      case (key, TagValue.False) =>
-        val tag = new Tag(key, TagType.BOOL).setVBool(false)
-        convertedSpan.tags.add(tag)
-
-      case (key, TagValue.String(string)) =>
-        val tag = new Tag(key, TagType.STRING).setVStr(string)
-        convertedSpan.tags.add(tag)
-
-      case (key, TagValue.Number(number)) =>
-        val tag = new Tag(key, TagType.LONG).setVLong(number)
-        convertedSpan.tags.add(tag)
-    }
-
-    kamonSpan.marks.foreach {
-      case Mark(instant, key) =>
-        val markTag = new Tag("event", TagType.STRING)
-        markTag.setVStr(key)
-        convertedSpan.addToLogs(
-          new Log(Clock.toEpochMicros(instant),
-                  java.util.Collections.singletonList(markTag)))
+    kamonSpan.marks.foreach { m =>
+      val markTag = new Tag("event", TagType.STRING)
+      markTag.setVStr(m.key)
+      convertedSpan.addToLogs(
+        new Log(
+          Clock.toEpochMicros(m.instant),
+          java.util.Collections.singletonList(markTag)
+        )
+      )
     }
 
     convertedSpan

--- a/src/main/scala/kamon/jaeger/JaegerReporter.scala
+++ b/src/main/scala/kamon/jaeger/JaegerReporter.scala
@@ -25,13 +25,18 @@ import kamon.util.Clock
 import kamon.Kamon
 import kamon.module.SpanReporter
 import kamon.trace.{Identifier, Span}
+import org.slf4j.LoggerFactory
 
 import scala.util.Try
 
 class JaegerReporter extends SpanReporter {
 
+  private val logger = LoggerFactory.getLogger(classOf[JaegerReporter])
+
   @volatile private var jaegerClient: JaegerClient = _
   reconfigure(Kamon.config())
+
+  logger.info("Started the Kamon Jaeger reporter")
 
   override def reconfigure(newConfig: Config): Unit = {
     val jaegerConfig = newConfig.getConfig("kamon.jaeger")
@@ -43,8 +48,9 @@ class JaegerReporter extends SpanReporter {
     jaegerClient = new JaegerClient(host, port, scheme, includeEnvironmentTags)
   }
 
-  override def start(): Unit = {}
-  override def stop(): Unit = {}
+  override def stop(): Unit = {
+    logger.info("Stopped the Kamon Jaeger reporter")
+  }
 
   override def reportSpans(spans: Seq[Span.Finished]): Unit = {
     jaegerClient.sendSpans(spans)

--- a/src/main/scala/kamon/jaeger/JaegerReporter.scala
+++ b/src/main/scala/kamon/jaeger/JaegerReporter.scala
@@ -107,7 +107,7 @@ class JaegerClient(host: String,
 
     import scala.collection.JavaConverters._
     convertedSpan.setTags(
-      kamonSpan.tags.iterator().map {
+      (kamonSpan.tags.iterator() ++ kamonSpan.metricTags.iterator()).map {
         case t: kamon.tag.Tag.String =>
           new Tag(t.key, TagType.STRING).setVStr(t.value)
         case t: kamon.tag.Tag.Boolean =>

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.3-SNAPSHOT"
+version in ThisBuild := "2.0.0-SNAPSHOT"


### PR DESCRIPTION
Also switches to using the shaded apache thrift jar. I'm not sure
this is what's desired, but it's an option to reduce the binary
compatibility issues if any consumers here are using incompatible
versions of thrift, okhttp, or gson