### PR TITLE
Add reporter for jaeger agent

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,7 +1,13 @@
 kamon {
   jaeger {
+    # If spans should be sent to jaeger agent (UDP/Thrift compact) instead of the collector (HTTP(S)/Thrift binary).
+    use-agent = false
+
     host = "localhost"
     port = 14268
+    agent-port = 6831
+
+    # Only relevant if using HTTP sender
     tls = false
 
     # Enable or disable including tags from kamon.jaeger.environment as labels

--- a/src/main/scala/kamon/jaeger/JaegerClient.scala
+++ b/src/main/scala/kamon/jaeger/JaegerClient.scala
@@ -1,0 +1,138 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2019 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.jaeger
+
+import com.typesafe.config.Config
+import io.jaegertracing.thrift.internal.reporters.protocols.ThriftUdpTransport
+import io.jaegertracing.thrift.internal.senders.{HttpSender, ThriftSender, ThriftSenderBase, UdpSender}
+import io.jaegertracing.thriftjava.{Process, Tag, TagType, Span => JaegerSpan}
+import kamon.Kamon
+import kamon.trace.Span
+import org.apache.thrift.TBase
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.util.{Failure, Success, Try}
+
+object JaegerClient {
+  def apply(config: Config): JaegerClient = {
+    val jaegerConfig = config.getConfig("kamon.jaeger")
+    val useAgent = jaegerConfig.getBoolean("use-agent")
+    val host = jaegerConfig.getString("host")
+    val includeEnvTags = jaegerConfig.getBoolean("include-environment-tags")
+
+    if(useAgent) {
+      val port = jaegerConfig.getInt("agent-port")
+      buildAgentClient(host, port, includeEnvTags)
+    } else {
+      val port = jaegerConfig.getInt("port")
+      val tls = jaegerConfig.getBoolean("tls")
+      buildCollectorClient(host, port, tls, includeEnvTags)
+    }
+  }
+
+  private def buildAgentClient(host: String, port: Int, includeEnvTags: Boolean): JaegerClient = {
+    val agentMaxPacketSize = ThriftUdpTransport.MAX_PACKET_SIZE
+    val agentBatchOverhead = ThriftSenderBase.EMIT_BATCH_OVERHEAD
+    val sender = new UdpSender(host, port, agentMaxPacketSize)
+    val jaegerSender = new JaegerSender(sender, includeEnvTags)
+    new JaegerClient(Some(agentMaxPacketSize - agentBatchOverhead), jaegerSender)
+  }
+
+  private def buildCollectorClient(host: String, port: Int, tls: Boolean, includeEnvTags: Boolean): JaegerClient = {
+    val scheme = if (tls) "https" else "http"
+    val endpoint = s"$scheme://$host:$port/api/traces"
+    val sender = new HttpSender.Builder(endpoint).build()
+    val jaegerSender = new JaegerSender(sender, includeEnvTags)
+    new JaegerClient(None, jaegerSender)
+  }
+}
+
+/**
+  * Wrapper class for a Thrift sender, enriching spans with environment tags.
+  */
+class JaegerSender(sender: ThriftSender, includeEnvTags: Boolean) {
+
+  private val log = LoggerFactory.getLogger(classOf[JaegerSender])
+  private val process = new Process(Kamon.environment.service)
+
+  if (includeEnvTags)
+    process.setTags(
+      Kamon.environment.tags.iterator(_.toString)
+        .map { p => new Tag(p.key, TagType.STRING).setVStr(p.value) }
+        .toList
+        .asJava)
+
+  /**
+    * The overhead (in bytes) required for process information in every batch.
+    */
+  val processOverhead = getSize(process)
+
+  def sendSpans(spans: mutable.Buffer[JaegerSpan]): Unit = {
+    if(spans.nonEmpty) {
+      Try(sender.send(process, spans.asJava)) match {
+        case Failure(e) =>
+          log.warn(s"Reporting spans to jaeger failed. ${spans.size} spans discarded.", e)
+        case Success(_) =>
+          log.debug(s"${spans.size} spans reported to jaeger.")
+      }
+    }
+  }
+
+  /**
+    * Get the required size in bytes for an object using the sender's protocol
+    */
+  def getSize(thriftBase: TBase[_, _]): Int = sender.getSize(thriftBase)
+}
+
+/**
+  * Handles conversion from Kamon spans to Jaeger's thrift format,
+  * batches them according to a maximum packet size (optional), and
+  * sends them using the underlying sender.
+  */
+class JaegerClient(maxPacketSize: Option[Int], jaegerSender: JaegerSender) {
+
+  def sendSpans(spans: Seq[Span.Finished]): Unit = {
+    if(maxPacketSize.isDefined) sendSpansBatched(spans, maxPacketSize.get) else sendAllSpans(spans)
+  }
+
+  private def sendAllSpans(spans: Seq[Span.Finished]): Unit = {
+    jaegerSender.sendSpans(spans.map(JaegerSpanConverter.convertSpan).toBuffer)
+  }
+
+  private def sendSpansBatched(spans: Seq[Span.Finished], maxPacketSize: Int): Unit = {
+    var bufferBytes = 0
+    var buffer: mutable.Buffer[JaegerSpan] = mutable.Buffer()
+    for(kamonSpan <- spans) {
+      val span = JaegerSpanConverter.convertSpan(kamonSpan)
+      val spanBytes = jaegerSender.getSize(span)
+
+      if(bufferBytes + spanBytes > maxPacketSize - jaegerSender.processOverhead) {
+        jaegerSender.sendSpans(buffer)
+        bufferBytes = 0
+        buffer = mutable.Buffer()
+      }
+
+      bufferBytes += spanBytes
+      buffer ++= mutable.Buffer(span)
+    }
+
+    // Flush buffer by sending remaining spans
+    jaegerSender.sendSpans(buffer)
+  }
+}

--- a/src/main/scala/kamon/jaeger/JaegerReporter.scala
+++ b/src/main/scala/kamon/jaeger/JaegerReporter.scala
@@ -16,18 +16,11 @@
 
 package kamon.jaeger
 
-import java.nio.ByteBuffer
-
 import com.typesafe.config.Config
-import io.jaegertracing.thrift.internal.senders.HttpSender
-import io.jaegertracing.thriftjava.{Log, Process, Tag, TagType, Span => JaegerSpan}
-import kamon.util.Clock
-import kamon.{module, Kamon}
+import kamon.module
 import kamon.module.{ModuleFactory, SpanReporter}
-import kamon.trace.{Identifier, Span}
+import kamon.trace.Span
 import org.slf4j.LoggerFactory
-
-import scala.util.Try
 
 class JaegerReporterFactory extends ModuleFactory {
   override def create(settings: ModuleFactory.Settings): module.Module = {
@@ -54,95 +47,3 @@ class JaegerReporter(@volatile private var jaegerClient: JaegerClient) extends S
   }
 }
 
-object JaegerClient {
-
-  def apply(config: Config): JaegerClient = {
-    val jaegerConfig = config.getConfig("kamon.jaeger")
-    val host = jaegerConfig.getString("host")
-    val port = jaegerConfig.getInt("port")
-    val scheme = if (jaegerConfig.getBoolean("tls")) "https" else "http"
-    val includeEnvironmentTags = jaegerConfig.getBoolean("include-environment-tags")
-    new JaegerClient(host, port, scheme, includeEnvironmentTags)
-  }
-}
-
-class JaegerClient(host: String,
-                   port: Int,
-                   scheme: String,
-                   includeEnvironmentTags: Boolean) {
-  import scala.collection.JavaConverters._
-
-  val endpoint = s"$scheme://$host:$port/api/traces"
-  val process = new Process(Kamon.environment.service)
-
-  if (includeEnvironmentTags)
-    process.setTags(
-      Kamon.environment.tags.iterator(_.toString)
-        .map { p => new Tag(p.key, TagType.STRING).setVStr(p.value) }
-        .toList
-        .asJava)
-
-  val sender = new HttpSender.Builder(endpoint).build()
-
-  def sendSpans(spans: Seq[Span.Finished]): Unit = {
-    val convertedSpans = spans.map(convertSpan).asJava
-    sender.send(process, convertedSpans)
-  }
-
-  private def convertSpan(kamonSpan: Span.Finished): JaegerSpan = {
-    val from = Clock.toEpochMicros(kamonSpan.from)
-    val duration =
-      Math.floorDiv(Clock.nanosBetween(kamonSpan.from, kamonSpan.to), 1000)
-
-    val (traceIdHigh, traceIdLow) = convertDoubleSizeIdentifier(kamonSpan.trace.id)
-    val convertedSpan = new JaegerSpan(
-      traceIdLow,
-      traceIdHigh,
-      convertIdentifier(kamonSpan.id),
-      convertIdentifier(kamonSpan.parentId),
-      kamonSpan.operationName,
-      0,
-      from,
-      duration
-    )
-
-    import scala.collection.JavaConverters._
-    convertedSpan.setTags(
-      (kamonSpan.tags.iterator() ++ kamonSpan.metricTags.iterator()).map {
-        case t: kamon.tag.Tag.String =>
-          new Tag(t.key, TagType.STRING).setVStr(t.value)
-        case t: kamon.tag.Tag.Boolean =>
-          new Tag(t.key, TagType.BOOL).setVBool(t.value)
-        case t: kamon.tag.Tag.Long =>
-          new Tag(t.key, TagType.LONG).setVLong(t.value)
-      }.toList.asJava
-    )
-
-    kamonSpan.marks.foreach { m =>
-      val markTag = new Tag("event", TagType.STRING)
-      markTag.setVStr(m.key)
-      convertedSpan.addToLogs(
-        new Log(
-          Clock.toEpochMicros(m.instant),
-          java.util.Collections.singletonList(markTag)
-        )
-      )
-    }
-
-    convertedSpan
-  }
-
-  private def convertIdentifier(identifier: Identifier): Long =
-    Try {
-      // Assumes that Kamon was configured to use the default identity generator.
-      ByteBuffer.wrap(identifier.bytes).getLong
-    }.getOrElse(0L)
-
-  private def convertDoubleSizeIdentifier(identifier: Identifier): (Long, Long) =
-    Try {
-      val buffer = ByteBuffer.wrap(identifier.bytes)
-      (buffer.getLong, buffer.getLong)
-    } getOrElse {
-      (0L, convertIdentifier(identifier))
-    }
-}

--- a/src/main/scala/kamon/jaeger/JaegerSpanConverter.scala
+++ b/src/main/scala/kamon/jaeger/JaegerSpanConverter.scala
@@ -1,0 +1,84 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2019 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.jaeger
+
+import java.nio.ByteBuffer
+
+import io.jaegertracing.thriftjava.{Log, Tag, TagType, Span => JaegerSpan}
+import kamon.trace.{Identifier, Span}
+import kamon.util.Clock
+
+import scala.util.Try
+
+object JaegerSpanConverter {
+  def convertSpan(kamonSpan: Span.Finished): JaegerSpan = {
+    val from = Clock.toEpochMicros(kamonSpan.from)
+    val duration =
+      Math.floorDiv(Clock.nanosBetween(kamonSpan.from, kamonSpan.to), 1000)
+
+    val (traceIdHigh, traceIdLow) = convertDoubleSizeIdentifier(kamonSpan.trace.id)
+    val convertedSpan = new JaegerSpan(
+      traceIdLow,
+      traceIdHigh,
+      convertIdentifier(kamonSpan.id),
+      convertIdentifier(kamonSpan.parentId),
+      kamonSpan.operationName,
+      0,
+      from,
+      duration
+    )
+
+    import scala.collection.JavaConverters._
+    convertedSpan.setTags(
+      (kamonSpan.tags.iterator() ++ kamonSpan.metricTags.iterator()).map {
+        case t: kamon.tag.Tag.String =>
+          new Tag(t.key, TagType.STRING).setVStr(t.value)
+        case t: kamon.tag.Tag.Boolean =>
+          new Tag(t.key, TagType.BOOL).setVBool(t.value)
+        case t: kamon.tag.Tag.Long =>
+          new Tag(t.key, TagType.LONG).setVLong(t.value)
+      }.toList.asJava
+    )
+
+    kamonSpan.marks.foreach { m =>
+      val markTag = new Tag("event", TagType.STRING)
+      markTag.setVStr(m.key)
+      convertedSpan.addToLogs(
+        new Log(
+          Clock.toEpochMicros(m.instant),
+          java.util.Collections.singletonList(markTag)
+        )
+      )
+    }
+
+    convertedSpan
+  }
+
+  private def convertIdentifier(identifier: Identifier): Long =
+    Try {
+      // Assumes that Kamon was configured to use the default identity generator.
+      ByteBuffer.wrap(identifier.bytes).getLong
+    }.getOrElse(0L)
+
+  private def convertDoubleSizeIdentifier(identifier: Identifier): (Long, Long) =
+    Try {
+      val buffer = ByteBuffer.wrap(identifier.bytes)
+      (buffer.getLong, buffer.getLong)
+    } getOrElse {
+      (0L, convertIdentifier(identifier))
+    }
+}


### PR DESCRIPTION
fixes #11 

Adding possibility to configure the jaeger integration to report spans to a local jaeger agent (over UDP/Thrift compact) instead of directly to the jaeger collector (over HTTP/Thrift binary).

In order to reuse most of the existing functionality, I restructured the existing code:
- The functionality in `JaegerSpanConverter` is a copy-paste without any changes. 
- Moved `JaegerClient` to its own file and refactored to allow for both methods without breaking API changes. 